### PR TITLE
fixed v4l2 sink

### DIFF
--- a/src/DslSinkBintr.cpp
+++ b/src/DslSinkBintr.cpp
@@ -3239,10 +3239,9 @@ namespace DSL
         }
 
         if (!m_pQueue->LinkToSink(m_pTransform) or
-            !m_pTransform->LinkToSink(m_pCapsFilter) or    
-            !m_pCapsFilter->LinkToSink(m_pSink))
-            // !m_pCapsFilter->LinkToSink(m_pIdentity) or
-            // !m_pIdentity->LinkToSink(m_pSink))
+            !m_pTransform->LinkToSink(m_pCapsFilter) or
+            !m_pCapsFilter->LinkToSink(m_pIdentity) or
+            !m_pIdentity->LinkToSink(m_pSink))
         {
             return false;
         }


### PR DESCRIPTION
When attempting to run the pipeline with a v4l2 sink, the capability negotiation on the pads failed due to frame dimensions. This problem was introduced in v0.29.alpha, the identity element was removed because of some refactoring. 

The fix was to basically add the m_pIdentity element back to the v4l2 sink bin. This was necessary for caps negotiation of the virtual device.