### PR TITLE
Fix multi source error

### DIFF
--- a/src/DslPipelineBintr.cpp
+++ b/src/DslPipelineBintr.cpp
@@ -91,8 +91,10 @@ namespace DSL
         {
             return false;
         }
-        // Add PipelineSourcesBintr as chid of this PipelineBintr.
-        GstNodetr::AddChild(m_pPipelineSourcesBintr);
+        // Add PipelineSourcesBintr as child of this PipelineBintr.
+        if (!GstNodetr::IsChild( m_pPipelineSourcesBintr ))
+            GstNodetr::AddChild(m_pPipelineSourcesBintr);
+
 
         return true;
     }


### PR DESCRIPTION
Pipeline source bin was being added multiple times as several sources are added. The fix is to only add the bin once and add the new elements to the bin. 